### PR TITLE
fix for initial session setup for unauthenticated apps

### DIFF
--- a/lib/phoenix_live_session.ex
+++ b/lib/phoenix_live_session.ex
@@ -225,8 +225,10 @@ defmodule PhoenixLiveSession do
   """
   @spec maybe_subscribe(Phoenix.LiveView.Socket.t(), Plug.Session.Store.session()) ::
           Phoenix.LiveView.Socket.t()
-  def maybe_subscribe(socket, %{__sid__: sid, __opts__: opts}) do
+  def maybe_subscribe(socket, session) do
     if LiveView.connected?(socket) do
+      sid = Map.fetch!(session, :__sid__)
+      opts = Map.fetch!(session, :__opts__)
       pub_sub = Keyword.fetch!(opts, :pub_sub)
       channel = "live_session:#{sid}"
       PubSub.subscribe(pub_sub, channel)


### PR DESCRIPTION
Seems like an initial request that renders a live-view but hasn't established a session yet will call the render function with an empty map instead of a session.  Since `maybe_subscribe/2` doesn't do anything with unconnected sockets anyways, this changes the code to be more forgiving when receiving the empty session object.

This should address pentacent/phoenix_live_session#6.