### PR TITLE
Allow for testing environments where session keys get turned into strings

### DIFF
--- a/lib/phoenix_live_session.ex
+++ b/lib/phoenix_live_session.ex
@@ -180,8 +180,8 @@ defmodule PhoenixLiveSession do
 
   defp put_meta(data, sid, opts) do
     data
-    |> Map.put(:__sid__, sid)
-    |> Map.put(:__opts__, opts)
+    |> Map.put("__sid__", sid)
+    |> Map.put("__opts__", opts)
   end
 
   defp maybe_clean(opts) do
@@ -225,19 +225,17 @@ defmodule PhoenixLiveSession do
   """
   @spec maybe_subscribe(Phoenix.LiveView.Socket.t(), Plug.Session.Store.session()) ::
           Phoenix.LiveView.Socket.t()
-  def maybe_subscribe(socket, session) do
+  def maybe_subscribe(socket, %{"__sid__" => sid, "__opts__" => opts}) do
     if LiveView.connected?(socket) do
-      sid = Map.fetch!(session, :__sid__)
-      opts = Map.fetch!(session, :__opts__)
       pub_sub = Keyword.fetch!(opts, :pub_sub)
-      channel = "live_session:#{sid}"
-      PubSub.subscribe(pub_sub, channel)
+      PubSub.subscribe(pub_sub, "live_session:#{sid}")
 
       put_in(socket.private[:live_session], id: sid, opts: opts)
     else
       socket
     end
   end
+  def maybe_subscribe(socket, _), do: socket
 
   @doc """
   This function can be called in two ways:any()
@@ -263,8 +261,8 @@ defmodule PhoenixLiveSession do
     socket
   end
 
-  @spec put_session(%{__sid__: String.t(), __opts__: list()}, String.t() | atom(), term()) :: %{}
-  def put_session(%{__sid__: sid, __opts__: opts}, key, value) do
+  @spec put_session(%{"__sid__" => String.t(), "__opts__" => list()}, String.t() | atom(), term()) :: %{}
+  def put_session(%{"__sid__" => sid, "__opts__" =>  opts}, key, value) do
     put_in(sid, to_string(key), value, opts)
 
     get(nil, sid, opts)

--- a/lib/phoenix_live_session.ex
+++ b/lib/phoenix_live_session.ex
@@ -235,6 +235,7 @@ defmodule PhoenixLiveSession do
       socket
     end
   end
+
   def maybe_subscribe(socket, _), do: socket
 
   @doc """
@@ -262,7 +263,7 @@ defmodule PhoenixLiveSession do
   end
 
   @spec put_session(map(), String.t() | atom(), term()) :: %{}
-  def put_session(%{"__sid__" => sid, "__opts__" =>  opts}, key, value) do
+  def put_session(%{"__sid__" => sid, "__opts__" => opts}, key, value) do
     put_in(sid, to_string(key), value, opts)
 
     get(nil, sid, opts)

--- a/lib/phoenix_live_session.ex
+++ b/lib/phoenix_live_session.ex
@@ -261,7 +261,7 @@ defmodule PhoenixLiveSession do
     socket
   end
 
-  @spec put_session(%{"__sid__" => String.t(), "__opts__" => list()}, String.t() | atom(), term()) :: %{}
+  @spec put_session(map(), String.t() | atom(), term()) :: %{}
   def put_session(%{"__sid__" => sid, "__opts__" =>  opts}, key, value) do
     put_in(sid, to_string(key), value, opts)
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule PhoenixLiveSession.MixProject do
     %{
       description: "In-memory live sessions for LiveViews and Phoenix controllers.",
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/pentacent/phoenix_live_session"},
+      links: %{"GitHub" => "https://github.com/pentacent/phoenix_live_session"}
     }
   end
 


### PR DESCRIPTION
This resolves #12.

All session keys in a `Plug.Conn` get turned into strings, so there's no way to setup the `maybe_subscribe` for success in a test environment. This could be me just misunderstanding the situation.